### PR TITLE
Adding in missing risoNoFill() function def

### DIFF
--- a/lib/p5.riso.js
+++ b/lib/p5.riso.js
@@ -175,6 +175,10 @@ function clearRiso() {
   Riso.channels.forEach(c => c.clear());
 }
 
+function risoNoFill() {
+  Riso.channels.forEach(c => c.noFill());
+}
+
 function risoNoStroke() {
   Riso.channels.forEach(c => c.noStroke());
 }


### PR DESCRIPTION
Following `risoNoStroke()` pattern