### PR TITLE
Transparency Support

### DIFF
--- a/lib/p5.riso.js
+++ b/lib/p5.riso.js
@@ -164,7 +164,13 @@ class Riso extends p5.Graphics {
       newImage.pixels[i]   = this.channelColor[0];
       newImage.pixels[i+1] = this.channelColor[1];
       newImage.pixels[i+2] = this.channelColor[2];
-      newImage.pixels[i+3] = 255 - (img.pixels[i] + img.pixels[i+1] + img.pixels[i+2])/3;
+
+      if (img.pixels[i+3] < 255) {
+        newImage.pixels[i+3] = img.pixels[i+3];
+      }
+      else {
+        newImage.pixels[i+3] = 255 - (img.pixels[i] + img.pixels[i+1] + img.pixels[i+2])/3;
+      }
     }
     newImage.updatePixels();
     this._image(newImage, x, y, w, h);


### PR DESCRIPTION
I was noticing that when I tried to draw an image with transparency to a Riso layer, the alpha channel value would become inverted. I wrote this small fix for my own project, but I think it could be helpful for everyone!

You can see my tests for this fix here: https://github.com/erinachavez/p5.riso/tree/Users/erina/transparency_support_test/test