### PR TITLE
Fix a word 'GitHub'

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,7 +43,7 @@
         <p>p5.Riso.js is a p5.js library for generating files suitable for Risograph printing. It helps turn your sketches into multi-color prints.</p>
           <p>A <a href="https://en.wikipedia.org/wiki/Risograph">Risograph</a> is sort of like a photocopier combined with a screen printer. Just like in screen printing, it prints one color at a time, each as a separate layer. To prepare digital files for riso printing, images need to be separated into individual colors, each saved out as a file. The p5.Riso Library helps automate color separation and lets you preview of how your prints will look. It makes it possible to turn your interactive p5 sketches into print art!
         </p>
-        <p>Full source and examples on <a href="https://github.com/antiboredom/p5.riso">Github</a>.</p>
+        <p>Full source and examples on <a href="https://github.com/antiboredom/p5.riso">GitHub</a>.</p>
         <h3>Installation</h3>
         <h4>Local</h4>
         <ul>


### PR DESCRIPTION
This PR fixes the word 'GitHub' (Just capitalize 'H').