### PR TITLE
Add instance mode

### DIFF
--- a/examples/Instance_mode/index.html
+++ b/examples/Instance_mode/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>p5.riso example using P5's instance mode</title>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/p5.js"></script>
+  <script src="../../lib/p5.riso.js"></script>
+
+  <script src="sketch.js"></script>
+
+  <style>
+    body {
+      background-color: #eee;
+    }
+  </style>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/examples/Instance_mode/readme.md
+++ b/examples/Instance_mode/readme.md
@@ -1,0 +1,23 @@
+# Instance mode example
+
+This is a copy of the color layerting example, but demonstrating the
+use of P5's [instance mode](https://p5js.org/reference/#/p5/p5)
+
+In order for p5.riso to be usable in this mode, you must set the
+`window._p5Instance` global variable to point to your local p5 instance.
+
+```javascript
+const sketch = function (p) {
+  p.setup = function() {
+    window._p5Instance = p;
+    // ...
+  }
+  p.draw = function() {
+    // ...
+  }
+}
+
+// Create the custom instance.
+const myp5 = new p5(sketch);
+
+```

--- a/examples/Instance_mode/sketch.js
+++ b/examples/Instance_mode/sketch.js
@@ -1,0 +1,63 @@
+// Example adapted from the color_test example, to demonstrate using
+// the library in P5/s instant mode. The color_test example is adapted from
+// Paola Dutra and Crystal Chen
+
+const sketch = function (p) {
+  let blue;
+  let yellow;
+  let red;
+
+  p.setup = function() {
+    // Set up a global object to capture this instance.
+    window._p5Instance = p;
+    p.createCanvas(600, 600);
+    p.pixelDensity(1);
+    p.noStroke();
+
+    red = new Riso("red");
+    blue = new Riso("blue");
+    yellow = new Riso("yellow");
+
+    p.colorGrid(red, 0);
+    p.colorGrid(yellow, 90);
+    p.colorGrid(blue, 270);
+
+    drawRiso();
+  }
+
+  p.draw = function() {}
+
+  p.mouseClicked = function() {
+    exportRiso();
+  }
+
+  p.colorGrid = function(layer, angle) {
+    deg = angle*(p.PI/180);
+    layer.push();
+    layer.translate(299,299);
+    layer.rotate(deg);
+    layer.translate(-299,-299);
+    //GRID
+    layer.noStroke();
+    for (var x = 0; x < 20; x++) {
+      for (var y = 0; y < 20; y++) {
+        let a = p.map(y, 0, 19, 255, 0);
+        let w = p.map(x, 0, 20, 50, 550);
+        let h = p.map(y, 0, 20, 50, 550);
+        layer.fill(a);
+        layer.rect(w, h, 23, 23);
+
+        //key
+        if(w>510){ //only draw edge strip once
+        layer.rect(550+30, h, 23, 23);
+        }
+      }
+    }
+    layer.pop();
+  }
+}
+
+// Create the custom instance.
+const myp5 = new p5(sketch);
+
+

--- a/lib/p5.riso.js
+++ b/lib/p5.riso.js
@@ -81,12 +81,17 @@ const RISOCOLORS = [
   {name: 'FLUORESCENTGREEN', color: [68, 214, 44]}
 ];
 
+function _getP5Instance() {
+  return window._p5Instance || p5.instance
+}
+
 class Riso extends p5.Graphics {
   constructor(channelColor, w, h) {
-    if (!w) w = width;
-    if (!h) h = height;
+    const p = _getP5Instance();
+    if (!w) w = p.width;
+    if (!h) h = p.height;
 
-    super(w, h, null, p5.instance);
+    super(w, h, null, p);
 
     let foundColor;
 
@@ -125,7 +130,8 @@ class Riso extends p5.Graphics {
     }
 
     //this.filter(GRAY);
-    let buffer = createGraphics(this.width, this.height);
+    const p = _getP5Instance();
+    let buffer = p.createGraphics(this.width, this.height);
 
     buffer.loadPixels();
     this.loadPixels();
@@ -157,8 +163,9 @@ class Riso extends p5.Graphics {
   }
 
   image(img, x, y, w, h) {
-    let alphaValue = alpha(this.drawingContext.fillStyle)/255;
-    let newImage = createImage(img.width, img.height);
+    const p = _getP5Instance()
+    let alphaValue = p.alpha(this.drawingContext.fillStyle)/255;
+    let newImage = p.createImage(img.width, img.height);
     img.loadPixels();
     newImage.loadPixels();
     for (let i=0; i < newImage.pixels.length; i+=4) {
@@ -178,14 +185,15 @@ class Riso extends p5.Graphics {
   }
 
   draw() {
-    image(this, 0, 0);
+    _getP5Instance().image(this, 0, 0);
   }
 }
 
 function drawRiso() {
-  blendMode(MULTIPLY);
+  const p = _getP5Instance();
+  p.blendMode(p.MULTIPLY);
   Riso.channels.forEach(c => c.draw());
-  blendMode(BLEND);
+  p.blendMode(p.BLEND);
 }
 
 function exportRiso() {
@@ -227,8 +235,9 @@ function extractRGBChannel(img, c) {
   if (c == "r" || c == "red") c = 0;
   if (c == "g" || c == "green") c = 1;
   if (c == "b" || c == "blue") c = 2;
+  const p = _getP5Instance();
 
-  let channel = createImage(img.width, img.height);
+  let channel = p.createImage(img.width, img.height);
   img.loadPixels();
   channel.loadPixels();
   for (let i = 0; i < img.pixels.length; i+=4) {
@@ -242,6 +251,8 @@ function extractRGBChannel(img, c) {
 }
 
 function extractCMYKChannel(img, c) {
+  const p = _getP5Instance();
+
   let desiredCMYKChannels = [];
   if(typeof c == "number" && c < 4) {
     desiredCMYKChannels.push(c);
@@ -252,7 +263,7 @@ function extractCMYKChannel(img, c) {
     if (c == "yellow" || c.includes("y")) desiredCMYKChannels.push(2);
     if (c == "black" || c.includes("k")) desiredCMYKChannels.push(3);
   }
-  let channel = createImage(img.width, img.height);
+  let channel = p.createImage(img.width, img.height);
   img.loadPixels();
   channel.loadPixels();
   for (let i = 0; i < img.pixels.length; i+=4) {
@@ -304,9 +315,11 @@ function halftoneImage(img, shape, frequency, angle, intensity) {
   const w = img.width;
   const h = img.height;
 
-  const rotatedCanvas = createGraphics(img.width*2, img.height*2);
+  const p = _getP5Instance();
+
+  const rotatedCanvas = p.createGraphics(img.width*2, img.height*2);
   rotatedCanvas.background(255);
-  rotatedCanvas.imageMode(CENTER);
+  rotatedCanvas.imageMode(p.CENTER);
   rotatedCanvas.push();
   rotatedCanvas.translate(img.width, img.height);
   rotatedCanvas.rotate(-angle);
@@ -314,10 +327,10 @@ function halftoneImage(img, shape, frequency, angle, intensity) {
   rotatedCanvas.pop();
   rotatedCanvas.loadPixels();
 
-  const out = createGraphics(w*2, h*2);
+  const out = p.createGraphics(w*2, h*2);
   out.background(255);
-  out.ellipseMode(CORNER);
-  out.rectMode(CENTER);
+  out.ellipseMode(p.CORNER);
+  out.rectMode(p.CENTER);
   out.fill(0);
   out.noStroke();
 


### PR DESCRIPTION
Fixes #14 

This basically looks for the presence of a `window._p5Instance` global being set, and if it's present, uses that instead of the global `p5`. This is a bit of a hack, but otherwise any functions that use a global `p5` function (like `createGraphics`, etc) would need to change their signature. This would be particularly annoying for functions like `halftone` which have a lot of optional parameters, and in order to have this not be a breaking change you'd have to have the "instance" parameter last, but then you have to specify the rest of the parameters, ugh ugh.

I am not at all married to the name `_p5Instance` (can add more underscores, can add a riso in there, etc), nor to the name of the function that's called everywhere in the library.

I reproed the color_test example, and she works!
<img width="623" alt="Screen Shot 2021-02-02 at 2 21 43 PM" src="https://user-images.githubusercontent.com/1369170/106671028-b30b6180-6562-11eb-8979-d3ac4393009e.png">
 