### PR TITLE
halfToneImage bug fix

### DIFF
--- a/lib/p5.riso.js
+++ b/lib/p5.riso.js
@@ -601,17 +601,21 @@ function halftoneImage(img, shape, frequency, angle, intensity) {
 
   const p = _getP5Instance();
 
-  const rotatedCanvas = p.createGraphics(img.width * 2, img.height * 2);
+  const longerSide = Math.max(w, h);
+  const canvasMultiplier = 2;
+  const canvasSide = longerSide * canvasMultiplier;
+
+  const rotatedCanvas = p.createGraphics(canvasSide, canvasSide);
   rotatedCanvas.background(255);
   rotatedCanvas.imageMode(p.CENTER);
   rotatedCanvas.push();
-  rotatedCanvas.translate(img.width, img.height);
+  rotatedCanvas.translate(longerSide, longerSide);
   rotatedCanvas.rotate(-angle);
   rotatedCanvas.image(img, 0, 0);
   rotatedCanvas.pop();
   rotatedCanvas.loadPixels();
 
-  const out = p.createGraphics(w * 2, h * 2);
+  const out = p.createGraphics(canvasSide, canvasSide);
   out.background(255);
   out.ellipseMode(p.CORNER);
   out.rectMode(p.CENTER);
@@ -620,9 +624,9 @@ function halftoneImage(img, shape, frequency, angle, intensity) {
 
   let gridsize = frequency;
 
-  for (let x = 0; x < w * 2; x += gridsize) {
-    for (let y = 0; y < h * 2; y += gridsize) {
-      const avg = rotatedCanvas.pixels[(x + y * w * 2) * 4];
+  for (let x=0; x < canvasSide; x+=gridsize) {
+    for (let y=0; y < canvasSide; y+=gridsize) {
+      const avg = rotatedCanvas.pixels[(x + y*longerSide*canvasMultiplier)* 4];
 
       if (avg < 255) {
         const darkness = (255 - avg) / 255;


### PR DESCRIPTION
For images that are very skinny (width much bigger than height, or vice versa), this picks the longer side to create a canvas for rotation. With the current code, the image ends up being cropped because the rotated canvas is not big enough.